### PR TITLE
Add subaccount functionality and fix transaction status de-sync

### DIFF
--- a/app/actions/payer.ts
+++ b/app/actions/payer.ts
@@ -113,6 +113,14 @@ export async function createPayerSubaccount(
     throw new Error('Payer not found');
   }
 
+  if (payer.subaccountId) {
+    return {
+      success: true,
+      subaccountId: payer.subaccountId,
+      name: parsed.name,
+    };
+  }
+
   const sub = await createRootSubaccount(parsed.name);
 
   await setPayer(payerId, {
@@ -124,6 +132,31 @@ export async function createPayerSubaccount(
   revalidatePath('/dashboard/payer');
 
   return { success: true, subaccountId: sub.id, name: sub.name };
+}
+
+/** Clear stored subaccount id (does not delete the remote Root subaccount). */
+export async function clearPayerSubaccount(
+  payerId: string
+): Promise<{ success: true }> {
+  const session = await getCurrentSession();
+  if (!sessionOwnsPayer(session, payerId)) {
+    throw new Error('Unauthorized');
+  }
+
+  const payer = await getPayer(payerId);
+  if (!payer) {
+    throw new Error('Payer not found');
+  }
+
+  await setPayer(payerId, {
+    ...payer,
+    subaccountId: undefined,
+    updatedAt: Date.now(),
+  });
+
+  revalidatePath('/dashboard/payer');
+
+  return { success: true };
 }
 
 /**

--- a/app/actions/payouts.ts
+++ b/app/actions/payouts.ts
@@ -76,7 +76,8 @@ export async function processPayout(
         payeeEmail: payee.email,
         amountCents,
         amount: item.amount,
-        status: payout.status || 'completed',
+        /** Snapshot at create time; list view replaces with live `GET /api/payouts/{rootPayoutId}`. */
+        status: payout.status || 'initiated',
         rootPayoutId: payout.id,
         rootTransactionId: payout.id,
         createdAt: Date.now(),

--- a/app/actions/transactions.ts
+++ b/app/actions/transactions.ts
@@ -2,18 +2,40 @@
 
 /**
  * Transaction listing server action.
+ *
+ * Ledger rows live in Redis (`rootPayoutId` is the Root payout id from `POST /api/payouts/`).
+ * Status is hydrated per row via `GET /api/payouts/{id}` so the UI reflects settlement on Root,
+ * not only the status captured at creation time.
  */
 
 import { getCurrentSession, sessionOwnsPayer } from '@/lib/session';
 import { getPayerTransactions } from '@/lib/redis';
+import { getPayoutStatus } from '@/lib/root-api';
 import type { Transaction } from '@/lib/types/payout';
 
-/** List all transactions for the calling payer, newest first. */
+/** List all transactions for the calling payer, newest first, with live payout status from Root. */
 export async function listTransactions(payerId: string): Promise<Transaction[]> {
   const session = await getCurrentSession();
   if (!sessionOwnsPayer(session, payerId)) {
     throw new Error('Unauthorized');
   }
   const transactions = (await getPayerTransactions(payerId)) as Transaction[];
-  return transactions;
+
+  const hydrated = await Promise.all(
+    transactions.map(async (t) => {
+      const payoutId = t.rootPayoutId?.trim();
+      if (!payoutId) return t;
+      try {
+        const remote = await getPayoutStatus(payoutId);
+        return {
+          ...t,
+          status: remote.status,
+        };
+      } catch {
+        return t;
+      }
+    }),
+  );
+
+  return hydrated.sort((a, b) => b.createdAt - a.createdAt);
 }

--- a/app/dashboard/payer/page.tsx
+++ b/app/dashboard/payer/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from 'next/navigation';
 import { DashboardHeader } from '@/components/DashboardHeader';
 import { BankAccountForm } from '@/components/BankAccountForm';
+import { PayerSubaccountSection } from '@/components/PayerSubaccountSection';
 import { getCurrentSession } from '@/lib/session';
 import { getPayer } from '@/lib/redis';
 import { branding } from '@/lib/branding';
@@ -60,7 +61,7 @@ export default async function PayerSettingsPage() {
         </Card>
 
         {/* Bank account card */}
-        <Card>
+        <Card className="mb-6">
           <CardHeader>
             <CardTitle>Bank account</CardTitle>
             <CardDescription>
@@ -91,6 +92,13 @@ export default async function PayerSettingsPage() {
             </div>
           </CardContent>
         </Card>
+
+        <PayerSubaccountSection
+          payerId={session.payerId}
+          payerName={payer.payerName}
+          subaccountId={payer.subaccountId}
+          hasLinkedBank={Boolean(payer.bankAccountToken)}
+        />
       </main>
     </div>
   );

--- a/app/dashboard/transactions/page.tsx
+++ b/app/dashboard/transactions/page.tsx
@@ -31,8 +31,8 @@ export default function TransactionsPage() {
   if (!session) return null;
 
   const totalPaidCents = transactions.reduce((sum, t) => sum + (t.amountCents ?? 0), 0);
-  const successfulTransactions = transactions.filter(
-    (t) => t.status === 'completed' || t.status === 'success'
+  const successfulTransactions = transactions.filter((t) =>
+    isSuccessfulPayoutStatus(t.status),
   ).length;
 
   return (
@@ -142,13 +142,34 @@ function StatCard({ label, value }: { label: string; value: string }) {
   );
 }
 
+/** Root `TransferStatus` and legacy Redis labels used before live hydration. */
+function isSuccessfulPayoutStatus(status: string): boolean {
+  const s = status.toLowerCase();
+  return s === 'settled' || s === 'completed' || s === 'success';
+}
+
 function StatusBadge({ status }: { status: string }) {
-  const map: Record<string, { label: string; variant: 'success' | 'warning' | 'destructive' | 'secondary' }> = {
+  const key = status.toLowerCase();
+  const map: Record<
+    string,
+    { label: string; variant: 'success' | 'warning' | 'destructive' | 'secondary' }
+  > = {
+    settled: { label: 'Settled', variant: 'success' },
     completed: { label: 'Settled', variant: 'success' },
     success: { label: 'Settled', variant: 'success' },
+    initiated: { label: 'Initiated', variant: 'warning' },
+    processing: { label: 'Processing', variant: 'warning' },
+    approved: { label: 'Approved', variant: 'warning' },
+    created: { label: 'Created', variant: 'warning' },
+    debited: { label: 'Debited', variant: 'warning' },
     pending: { label: 'Pending', variant: 'warning' },
+    needs_review: { label: 'Needs review', variant: 'warning' },
     failed: { label: 'Failed', variant: 'destructive' },
+    canceled: { label: 'Canceled', variant: 'secondary' },
   };
-  const { label, variant } = map[status] ?? { label: status, variant: 'secondary' };
+  const { label, variant } = map[key] ?? {
+    label: status.replace(/_/g, ' '),
+    variant: 'secondary' as const,
+  };
   return <Badge variant={variant}>{label}</Badge>;
 }

--- a/components/BankAccountForm.tsx
+++ b/components/BankAccountForm.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { useRouter } from 'next/navigation';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Loader2 } from 'lucide-react';
@@ -19,6 +20,7 @@ interface BankAccountFormProps {
 }
 
 export function BankAccountForm({ payerId, onSuccess }: BankAccountFormProps) {
+  const router = useRouter();
   const [linked, setLinked] = useState(false);
   const { linkBank, isSubmitting } = useLinkBank();
 
@@ -38,6 +40,7 @@ export function BankAccountForm({ payerId, onSuccess }: BankAccountFormProps) {
       toast.success('Bank account linked successfully');
       setLinked(true);
       reset();
+      router.refresh();
       if (onSuccess) onSuccess();
     } catch (err) {
       toast.error(err instanceof Error ? err.message : 'An error occurred');

--- a/components/PayerSubaccountSection.tsx
+++ b/components/PayerSubaccountSection.tsx
@@ -1,0 +1,229 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Loader2 } from 'lucide-react';
+import { toast } from 'sonner';
+import { branding } from '@/lib/branding';
+import { useFundSubaccountPayin, usePayerSubaccountToggle } from '@/lib/hooks/usePayer';
+import {
+  fundSubaccountPayinInputSchema,
+  type FundSubaccountPayinInput,
+} from '@/lib/types/fund';
+import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+type Props = {
+  payerId: string;
+  payerName: string;
+  subaccountId?: string;
+  hasLinkedBank: boolean;
+};
+
+export function PayerSubaccountSection({
+  payerId,
+  payerName,
+  subaccountId,
+  hasLinkedBank,
+}: Props) {
+  const router = useRouter();
+  const subaccountEnabled = Boolean(subaccountId);
+  const { enableSubaccount, disableSubaccount, isSubmitting: toggleBusy } =
+    usePayerSubaccountToggle();
+  const { fundPayin, isSubmitting: payinBusy } = useFundSubaccountPayin();
+
+  const defaultSubaccountName = `${payerName} · ${branding.productName} treasury`.slice(
+    0,
+    128,
+  );
+
+  async function handleToggle(enable: boolean) {
+    if (toggleBusy) return;
+    try {
+      if (enable) {
+        await enableSubaccount(payerId, defaultSubaccountName);
+        toast.success('Subaccount enabled');
+      } else {
+        await disableSubaccount(payerId);
+        toast.success('Subaccount disabled for this profile');
+      }
+      router.refresh();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Something went wrong');
+    }
+  }
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    reset,
+  } = useForm<FundSubaccountPayinInput>({
+    resolver: zodResolver(fundSubaccountPayinInputSchema),
+    defaultValues: {
+      amount: 10,
+      rail: 'standard_ach',
+    },
+  });
+
+  async function onPayinSubmit(data: FundSubaccountPayinInput) {
+    try {
+      const result = await fundPayin(payerId, data);
+      toast.success(
+        `Payin started — ${result.rail} (${result.payinId.slice(0, 8)}…)`,
+      );
+      reset({ amount: data.amount, rail: data.rail });
+      router.refresh();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Payin failed');
+    }
+  }
+
+  return (
+    <Card className="mb-6">
+      <CardHeader>
+        <CardTitle>Treasury subaccount</CardTitle>
+        <CardDescription>
+          Enable a Root subaccount and pull funds from your linked bank via ACH payins.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-6">
+        <div className="flex flex-col gap-4 rounded-lg border bg-muted/20 p-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="space-y-1">
+            <p className="text-sm font-medium">Enable subaccount functionality</p>
+            <p className="text-xs text-muted-foreground">
+              Calls Root to create a subaccount and saves its ID on your operator record.
+            </p>
+          </div>
+          <ToggleSwitch
+            checked={subaccountEnabled}
+            disabled={toggleBusy}
+            onCheckedChange={handleToggle}
+          />
+        </div>
+
+        {subaccountEnabled && subaccountId ? (
+          <div className="rounded-md border bg-background px-3 py-2">
+            <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              Root subaccount ID
+            </p>
+            <p className="font-mono text-xs break-all text-muted-foreground">{subaccountId}</p>
+          </div>
+        ) : null}
+
+        {subaccountEnabled ? (
+          <div className="flex flex-col gap-4 rounded-lg border bg-muted/30 p-4">
+            <div>
+              <p className="text-sm font-medium">Fund subaccount (ACH pull)</p>
+              <p className="text-xs text-muted-foreground mt-1">
+                Payin from your linked {branding.funderShortLabel.toLowerCase()} into this
+                subaccount using{' '}
+                <code className="rounded bg-muted px-1 py-0.5 text-[11px]">standard_ach</code>{' '}
+                or{' '}
+                <code className="rounded bg-muted px-1 py-0.5 text-[11px]">
+                  same_day_ach
+                </code>
+                .
+              </p>
+            </div>
+
+            {!hasLinkedBank ? (
+              <p className="text-sm text-amber-700 dark:text-amber-400">
+                Link your bank account above before starting a payin.
+              </p>
+            ) : (
+              <form onSubmit={handleSubmit(onPayinSubmit)} className="flex flex-col gap-4">
+                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                  <div className="flex flex-col gap-2">
+                    <Label htmlFor="payin-amount">Amount (USD)</Label>
+                    <Input
+                      id="payin-amount"
+                      type="number"
+                      step="0.01"
+                      min="0.01"
+                      {...register('amount', { valueAsNumber: true })}
+                      className="font-mono"
+                    />
+                    {errors.amount ? (
+                      <p className="text-xs text-destructive">{errors.amount.message}</p>
+                    ) : null}
+                  </div>
+                  <div className="flex flex-col gap-2">
+                    <Label htmlFor="payin-rail">ACH rail</Label>
+                    <select
+                      id="payin-rail"
+                      {...register('rail')}
+                      className={cn(
+                        'flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors',
+                        'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
+                      )}
+                    >
+                      <option value="standard_ach">standard_ach</option>
+                      <option value="same_day_ach">same_day_ach</option>
+                    </select>
+                    {errors.rail ? (
+                      <p className="text-xs text-destructive">{errors.rail.message}</p>
+                    ) : null}
+                  </div>
+                </div>
+                <Button type="submit" disabled={payinBusy} variant="secondary">
+                  {payinBusy ? (
+                    <>
+                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      Creating payin…
+                    </>
+                  ) : (
+                    'Pull funds into subaccount'
+                  )}
+                </Button>
+              </form>
+            )}
+          </div>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+}
+
+function ToggleSwitch({
+  checked,
+  disabled,
+  onCheckedChange,
+}: {
+  checked: boolean;
+  disabled?: boolean;
+  onCheckedChange: (next: boolean) => void;
+}) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      disabled={disabled}
+      onClick={() => onCheckedChange(!checked)}
+      className={cn(
+        'relative inline-flex h-8 w-14 shrink-0 rounded-full border-2 border-transparent transition-colors',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+        'disabled:pointer-events-none disabled:opacity-50',
+        checked ? 'bg-primary' : 'bg-input',
+      )}
+    >
+      <span
+        className={cn(
+          'pointer-events-none inline-block h-7 w-7 rounded-full bg-background shadow-md ring-0 transition-transform',
+          checked ? 'translate-x-6' : 'translate-x-0.5',
+        )}
+      />
+    </button>
+  );
+}

--- a/lib/hooks/usePayer.ts
+++ b/lib/hooks/usePayer.ts
@@ -8,7 +8,14 @@
  */
 
 import { useCallback, useState } from 'react';
-import { getCurrentPayer, linkPayerBank } from '@/app/actions/payer';
+import {
+  clearPayerSubaccount,
+  createPayerSubaccount,
+  fundPayerSubaccountPayin,
+  getCurrentPayer,
+  linkPayerBank,
+} from '@/app/actions/payer';
+import type { FundSubaccountPayinInput } from '@/lib/types/fund';
 import type { Payer, LinkBankInput } from '@/lib/types/payer';
 
 export function usePayer() {
@@ -52,4 +59,53 @@ export function useLinkBank() {
   }
 
   return { linkBank: submit, isSubmitting, error };
+}
+
+export function usePayerSubaccountToggle() {
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  async function enableSubaccount(payerId: string, subaccountDisplayName: string) {
+    setIsSubmitting(true);
+    try {
+      const result = await createPayerSubaccount(payerId, {
+        name: subaccountDisplayName,
+      });
+      return result;
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  async function disableSubaccount(payerId: string) {
+    setIsSubmitting(true);
+    try {
+      return await clearPayerSubaccount(payerId);
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return { enableSubaccount, disableSubaccount, isSubmitting };
+}
+
+export function useFundSubaccountPayin() {
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function submit(payerId: string, input: FundSubaccountPayinInput) {
+    setIsSubmitting(true);
+    setError(null);
+    try {
+      return await fundPayerSubaccountPayin(payerId, input);
+    } catch (err) {
+      const msg =
+        err instanceof Error ? err.message : 'Failed to create payin';
+      setError(msg);
+      throw err;
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return { fundPayin: submit, isSubmitting, error };
 }


### PR DESCRIPTION
## Summary

This PR introduces **payer subaccount functionality** along with fixes for **transaction status de-synchronization** between local storage and Root.

It enables payers to create and manage a Root subaccount, fund it via ACH pay-ins, and ensures transaction statuses reflect real-time data from Root instead of stale snapshots.

---

## Key Changes

### 1. Subaccount Management

* Added ability to **create and persist a Root subaccount** for a payer.
* Introduced `clearPayerSubaccount` to remove the stored subaccount reference (without deleting it remotely).
* Prevents duplicate subaccount creation if one already exists.

### 2. Subaccount Funding (Pay-ins)

* Implemented ACH pull flows (`standard_ach`, `same_day_ach`) to fund subaccounts.
* Added UI + hooks for initiating pay-ins from linked bank accounts.

### 3. UI Enhancements

* New `PayerSubaccountSection`:

  * Toggle to enable/disable subaccount functionality.
  * Displays subaccount ID.
  * Form to initiate pay-ins.
* Integrated into payer dashboard.
* Bank linking flow now triggers UI refresh on success.

### 4. Transaction Status Fix (De-sync Resolution)

* Transactions now **hydrate live status** using `GET /api/payouts/{id}`.
* Eliminates reliance on stale status stored at creation time.
* Added normalization helpers:

  * `isSuccessfulPayoutStatus`
  * Improved `StatusBadge` mapping

### 5. Payout Handling Adjustment

* Default payout status changed from `completed` → `initiated` at creation.
* Aligns local state with actual lifecycle on Root.

---

## Why This Matters

* Ensures **source-of-truth consistency** by syncing with Root APIs.
* Enables **end-to-end treasury flow**:

  * Link bank → create subaccount → fund via ACH → track transactions.
* Improves **UX clarity** with accurate, real-time statuses.

---

## Risks / Considerations

* Additional latency due to per-transaction status hydration.
* Increased dependency on Root API availability.
* Subaccount disable only clears local reference (remote resource persists).

---

## Testing Notes

* Enable subaccount → verify ID persistence.
* Fund subaccount via ACH → confirm pay-in initiation.
* Validate transaction list reflects **live status updates**.
* Toggle subaccount off → ensure local state is cleared correctly.

---

## Future Improvements

* Batch status hydration to reduce API calls.
* Add caching layer for payout status.
* Support subaccount deletion (if required by Root API).
* Improve retry/error handling for pay-ins.

---

## Checklist

* [x] Subaccount creation + toggle
* [x] ACH pay-in flow
* [x] Transaction status synchronization fix
* [x] UI integration
* [x] Backward compatibility maintained
